### PR TITLE
Sort schema paths

### DIFF
--- a/openapi-format.js
+++ b/openapi-format.js
@@ -87,7 +87,7 @@ async function openapiSort(oaObj, options) {
   });
 
   // Process root level
-  if (jsonObj.openapi) {
+  if (jsonObj.openapi || jsonObj.swagger) {
     jsonObj = prioritySort(jsonObj, sortSet['root'])
   }
 

--- a/openapi-format.js
+++ b/openapi-format.js
@@ -68,6 +68,12 @@ async function openapiSort(oaObj, options) {
       if (this.path[0] === 'components' && this.path[1] === 'examples' && this.path[3] === 'value') {
           // debugStep = 'Generic sorting - skip nested components>examples'
           // Skip nested components>examples values
+
+      } else if (this.parent && this.parent.isRoot && this.key == 'paths') {
+        // Paths sorting by alphabet
+        // debugStep = 'Generic sorting - paths';
+        this.update(prioritySort(node, sortSet[this.key]));
+
       } else {
         // debugStep = 'Generic sorting - properties'
         // Sort list of properties

--- a/util-sort.js
+++ b/util-sort.js
@@ -106,7 +106,7 @@ function prioritySort(jsonProp, sortPriority, options) {
 }
 
 /**
- * A check if the OpenAPI operation item matches a target definition .
+ * A check if the OpenAPI operation item matches a target definition.
  * @param {object} operationPath the OpenAPI path item to match
  * @param {object} operationMethod the OpenAPI method item to match
  * @param {string} target the entered operation definition that is a combination of the method & path, like GET::/lists


### PR DESCRIPTION
1. Adds support for processing a document with a `swagger` version attribute at the top level instead of `openapi`.
2. We need to be able to sort `paths` by name, obviously it's not possble to give a list of all paths in the config since these are not well-known values.   I'm not sure if this is the best approach but it works for me.